### PR TITLE
Ensure data dir paths are absolute

### DIFF
--- a/mlebench/competitions/the-icml-2013-whale-challenge-right-whale-redux/prepare.py
+++ b/mlebench/competitions/the-icml-2013-whale-challenge-right-whale-redux/prepare.py
@@ -43,7 +43,7 @@ def prepare(raw: Path, public: Path, private: Path):
         # Replace index part of filename with new index
         new_sample_name = re.sub(r"TRAIN\d+", f"TRAIN{idx}", sample.name)
         new_sample = public / "train2" / new_sample_name
-        shutil.copy(sample, public / "train2" / new_sample)
+        shutil.copy(sample, new_sample)
 
     answer_rows = []  # While we're at it, collect answers for the new test set
     (public / "test2").mkdir(exist_ok=True, parents=True)

--- a/mlebench/registry.py
+++ b/mlebench/registry.py
@@ -10,7 +10,7 @@ from mlebench.utils import get_logger, get_module_dir, get_repo_dir, import_fn, 
 logger = get_logger(__name__)
 
 
-DEFAULT_DATA_DIR = Path(user_cache_dir()) / "mle-bench" / "data"
+DEFAULT_DATA_DIR = (Path(user_cache_dir()) / "mle-bench" / "data").resolve()
 
 
 @dataclass(frozen=True)
@@ -73,7 +73,7 @@ class Competition:
 
 class Registry:
     def __init__(self, data_dir: Path = DEFAULT_DATA_DIR):
-        self._data_dir = data_dir
+        self._data_dir = data_dir.resolve()
 
     def get_competition(self, competition_id: str) -> Competition:
         """Fetch the competition from the registry."""


### PR DESCRIPTION
When preparing for public release, we changed the default data dir to be the user's cache dir, and enabled user-specified data dirs. 

We forgot to resolve these paths (make them absolute), which led to some downstream bugs with code that assumed an absolute (resolved) data dir (e.g. #20)

This PR adds those resolves.

For completeness, we also provide a more global fix to #20 with a fix in the comp's prepare script. 