### PR TITLE
pin miniconda version

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* # removes cache
 
 RUN pip install virtualenv \
-    && wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.1.1-1-Linux-x86_64.sh -O /tmp/miniconda.sh \
+    && wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.3.1-1-Linux-x86_64.sh -O /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -b -p /opt/conda \
     && rm /tmp/miniconda.sh \
     && /opt/conda/bin/conda init

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* # removes cache
 
 RUN pip install virtualenv \
-    && wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh \
+    && wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.1.1-1-Linux-x86_64.sh -O /tmp/miniconda.sh \
     && bash /tmp/miniconda.sh -b -p /opt/conda \
     && rm /tmp/miniconda.sh \
     && /opt/conda/bin/conda init


### PR DESCRIPTION
## Problem
The Dockerfile installs miniconda from miniconda-latest. 
As of Apr 30 (https://www.anaconda.com/docs/getting-started/miniconda/release/25.x) python3.13 is installed into the base environment. (miniconda skipped conda 25.3.0 where this change was made)
mlebench requires tensorflow which does not yet support py3.13

## Proposed fix

```diff
- Miniconda3-latest-Linux-x86_64.sh
+ Miniconda3-py312_25.1.1-1-Linux-x86_64.sh 
```
to ensure py3.12 is used.

If having miniconda-latest is desirable, this could also be addressed by immediately downgrading the conda base python installation after installing miniconda:

```
RUN /opt/conda/bin/conda install -y python=3.12
```