### PR TITLE
make and use a conda env for grading server

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -59,7 +59,9 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 # Install stuff for the grading server: mlebench and flask
 COPY . /mlebench
-RUN pip install flask && pip install -e /mlebench
+RUN /opt/conda/bin/conda create -n mleb python=3.11 -y
+RUN /opt/conda/bin/conda run -n mleb pip install flask && \
+    /opt/conda/bin/conda run -n mleb pip install -e /mlebench
 
 # Reset DEBIAN_FRONTEND
 ENV DEBIAN_FRONTEND=

--- a/environment/entrypoint.sh
+++ b/environment/entrypoint.sh
@@ -15,5 +15,5 @@ set -x
   ls -l /home
 
   # Launch grading server, stays alive throughout container lifetime to service agent requests.
-  /opt/conda/bin/python /private/grading_server.py
+  /opt/conda/bin/conda run -n mleb python /private/grading_server.py
 } 2>&1 | tee $LOGS_DIR/entrypoint.log


### PR DESCRIPTION
We were originally just installing mleb and flask to the _base_ conda environment for running the validation server, and therefore were not specifying a python version.

This caused issues when miniconda updated the version of python that the base environment runs. 

We address this in this PR by actually making and using a separate venv for the validation server. 

Fixes #50 