### PR TITLE
Fix champs-scalar-coupling to include test molecule structures

### DIFF
--- a/mlebench/competitions/champs-scalar-coupling/checksums.yaml
+++ b/mlebench/competitions/champs-scalar-coupling/checksums.yaml
@@ -7,7 +7,7 @@ public:
   potential_energy.csv: b30f3b3b2889e433487c3abdab6b6814
   sample_submission.csv: fbb4313c3052857027152c871900a0c4
   scalar_coupling_contributions.csv: 233037169b2a8f8ee1519c19c6eb7b6e
-  structures.csv: 6082e6a941b90bcabb7325f3bee64622
+  structures.csv: 4b8864143e5251cc9793e84cb62b12d1
   test.csv: 2c8b2fd3060697f3be78489290f40768
   train.csv: bc4222feab583532854367a124d93aaa
 zip: 2e7bb40d8e2b3488250f15430b8cf947


### PR DESCRIPTION
The prepare script explicitly filters structures to only include train molecules. This is incorrect for this competition --- in the [Kaggle competition](https://www.kaggle.com/competitions/champs-scalar-coupling/data), structures.csv contains all molecules (both train and test). The test molecules need their structures to make predictions, but they're being filtered out.

  ## Changes:
  - Modified prepare.py to include both train and test molecules in structures.csv
  - Updated checksums.yaml to reflect the new structures.csv checksum
  - Updated assertions to validate both train and test molecules

After fixing the data preparation issue, I used a LightGBM model trained on 25% of the data to make predictions:

```
  {
    "competition_id": "champs-scalar-coupling",
    "score": 0.5823,
    "gold_threshold": -2.87509,
    "silver_threshold": -2.03119,
    "bronze_threshold": -1.90122,
    "median_threshold": -0.9529,
    "any_medal": false,
    "gold_medal": false,
    "silver_medal": false,
    "bronze_medal": false,
    "above_median": false,
    "submission_exists": true,
    "valid_submission": true,
    "is_lower_better": true,
    "created_at": "2025-09-03T22:56:19.592098",
    "submission_path": "mlebench/competitions/champs-scalar-coupling/submission.csv"
  }
```
