### PR TITLE
[R&D-Agent] Update with New Results with gpt-5 on MLE-Bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 | Agent | Low == Lite (%) | Medium (%) | High (%) | All (%) | Running Time (hours) | Date | Grading Reports Available | Source Code Available 
 |---------|--------|-----------|---------|----------|--------|------|------|------|
 | [InternAgent](https://github.com/Alpha-Innovator/InternAgent/) deepseek-r1 | 62.12 ± 3.03 | 26.32 ± 2.63 | 24.44 ± 2.22| 36.44 ± 1.18 | 12 | 2025-09-12	 | ✓ | X |
+| [R&D-Agent](https://github.com/microsoft/RD-Agent) gpt-5 | 68.18 ± 2.62 | 21.05 ± 1.52 | 22.22 ± 2.22 | 35.11 ± 0.44 | 12 | 2025-09-26 | ✓ | ✓ |
 | [Neo](https://heyneo.so/) multi-agent | 48.48 ± 1.52 | 29.82 ± 2.32	| 24.44 ± 2.22 | 34.22 ± 0.89 | 36 | 2025-07-28 | ✓ | X |
-| [R&D-Agent](https://github.com/microsoft/RD-Agent) o3 + GPT-4.1 | 51.52 ± 6.9 | 19.3 ± 5.5 | 26.67 ± 0 | 30.22 ± 1.5 | 24 | 2025-08-15 | ✓ | ✓ |
+| [R&D-Agent](https://github.com/microsoft/RD-Agent) o3 + GPT-4.1 | 51.52 ± 4 | 19.3 ± 3.16 | 26.67 ± 0 | 30.22 ± 0.89 | 24 | 2025-08-15 | ✓ | ✓ |
 | [ML-Master](https://github.com/zeroxleo/ML-Master) deepseek-r1 | 48.5 ± 1.5 | 20.2 ± 2.3 | 24.4 ± 2.2| 29.3 ± 0.8 | 12 | 2025-06-17 | ✓ | ✓ |
-| [R&D-Agent](https://github.com/microsoft/RD-Agent) o1-preview | 48.18 ± 2.49 | 8.95 ± 2.36 | 18.67 ± 2.98 | 22.4 ± 1.1 | 24 | 2025-05-14 | ✓ | ✓ |
+| [R&D-Agent](https://github.com/microsoft/RD-Agent) o1-preview | 48.18 ± 1.1 | 8.95 ± 1.05 | 18.67 ± 1.33 | 22.4 ± 0.5 | 24 | 2025-05-14 | ✓ | ✓ |
 | AIDE o1-preview | 34.3 ± 2.4 | 8.8 ± 1.1 | 10.0 ± 1.9 | 16.9 ± 1.1 | 24 | 2024-10-08 | ✓ | ✓ |
 | AIDE gpt-4o-2024-08-06 | 19.0 ± 1.3 | 3.2 ± 0.5 | 5.6 ± 1.0 | 8.6 ± 0.5 | 24 | 2024-10-08 | ✓ | ✓ |
 | AIDE claude-3-5-sonnet-20240620 | 19.4 ± 4.9 | 2.6 ± 1.5 | 2.3 ± 2.3 | 7.5 ± 1.8 | 24 | 2024-10-08 | ✓ | ✓ |

--- a/runs/README.md
+++ b/runs/README.md
@@ -37,8 +37,9 @@ table below.
 | scaffolding-gpt4o-aide              | GPT-4o on AIDE scaffolding                                                 |
 | scaffolding-gpt4o-mlab              | GPT-4o on MLAB scaffolding                                                 |
 | scaffolding-gpt4o-opendevin         | GPT-4o on OpenDevin scaffolding                                            |
-| o1-preview-R&D-Agent                 | o1-preview on R&D-Agent scaffolding, 12 vCPUs, 220GB of RAM, and 1 V100 GPU |
+| o1-preview-R&D-Agent                | o1-preview on R&D-Agent scaffolding, 12 vCPUs, 220GB of RAM, and 1 V100 GPU |
 | deepseek-r1-ML-Master               | Deepseek-R1 on ML-Master scaffolding, 12 hours, 36 vCPUs, 512GB of RAM, and 1 A100 GPU|
 | multi-agent-Neo                     | Multi-Agent Ensemble of LLMs (GPT 4.1 and Claude Sonnet 4.0) on NEO scaffolding, 36 hours, 24 vCPUs, 144GB of RAM, and 1 A100 GPU|
-| o3-gpt-4.1-R&D-Agent                 | O3 as researcher and gpt-4.1 as developer on R&D-Agent scaffolding, 12 vCPUs, 220GB of RAM, and 1 V100 GPU |
-| deepseek-r1-InternAgent              | Deepseek-R1 on InternAgent scaffolding, 12 hours, 32 vCPUs, 230GB of RAM, and 1 A800 GPU|
+| o3-gpt-4.1-R&D-Agent                | O3 as researcher and gpt-4.1 as developer on R&D-Agent scaffolding, 12 vCPUs, 220GB of RAM, and 1 V100 GPU |
+| deepseek-r1-InternAgent             | Deepseek-R1 on InternAgent scaffolding, 12 hours, 32 vCPUs, 230GB of RAM, and 1 A800 GPU|
+| gpt-5-R&D-Agent                     | gpt-5 on R&D-Agent scaffolding, 12 hours, 12 vCPUs, 220GB of RAM, and 1 V100 GPU |

--- a/runs/rdagent_group10/grading_report_group_10.json
+++ b/runs/rdagent_group10/grading_report_group_10.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26c578360674c8656a09485a23f3b9c62eb3e6d45262039de74c291fc3aaecb4
+size 53298

--- a/runs/rdagent_group11/grading_report_group_11.json
+++ b/runs/rdagent_group11/grading_report_group_11.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea87540f744527a81fd280633b4f9163d990b99550a5e5b7d11f2d1446ef828c
+size 53290

--- a/runs/rdagent_group9/grading_report_group_9.json
+++ b/runs/rdagent_group9/grading_report_group_9.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9632101aa9174dad35b9a6ef5fa50559d30976d07f37f2e72262f31e1a2df29
+size 53293

--- a/runs/run_group_experiments.csv
+++ b/runs/run_group_experiments.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:35f73866db40f7bbab46d8a43e2d3197ba4a42b0bf4f28207378a73efdb4ed66
-size 3544
+oid sha256:756db378580f955b90490142cf40f6d8aad9af6e65306f0e4b24b7f80eca1b18
+size 3639


### PR DESCRIPTION
Hello authors of MLE-Bench,

We are the R&D-Agent team at Microsoft Research. With the latest R&D-Agent release using the GPT-5 base model, our agent achieves, to the best of our knowledge, a new state of the art among open-source agents on MLE-Bench: a 35.11% medal rate on the Full set.

As part of this pull request, we are contributing:
• Detailed grade reports in mle-bench/runs/R&Dagent_group[9-11], with three independent runs (seeds) for each competition, in line with recommended MLE-Bench practices.
• A summarized results table (below) reporting mean ± SEM over three seeds for each evaluation.

Correction to prior reporting:
In our previous submission, we inadvertently reported standard deviation (SD) rather than standard error of the mean (SEM). The corrected SEM values, computed from the per-seed JSON run files, are provided here. We apologize for the oversight.

We partially align the setting with our previous submission but shorten the time limit, which is as follows:
• For each run, we used 12 vCPUs, 220GB of RAM, and 1 V100 GPU —slightly below the default resource specifications in MLE-Bench.
• We aligned our resource usage as closely as possible with MLE-Bench’s guidelines.
• The time limit was shortened to 12 hours (half of the 24-hour budget specified by MLE-Bench).

Final proposed new result:
| Agent | Low == Lite (%) | Medium (%) | High (%) | All (%) | Running Time (hours) | Date | Grading Reports Available | Source Code Available 
|---------|--------|-----------|---------|----------|--------|------|------|------|
| [InternAgent](https://github.com/Alpha-Innovator/InternAgent/) deepseek-r1 | 62.12 ± 3.03 | 26.32 ± 2.63 | 24.44 ± 2.22| 36.44 ± 1.18 | 12 | 2025-09-12	 | ✓ | X |
| [R&D-Agent](https://github.com/microsoft/RD-Agent) gpt-5 | 68.18 ± 2.62 | 21.05 ± 1.52 | 22.22 ± 2.22 | 35.11 ± 0.44 | 12 | 2025-09-26 | ✓ | ✓ |
| [Neo](https://heyneo.so/) multi-agent | 48.48 ± 1.52 | 29.82 ± 2.32	| 24.44 ± 2.22 | 34.22 ± 0.89 | 36 | 2025-07-28 | ✓ | X |
| [R&D-Agent](https://github.com/microsoft/RD-Agent) o3 + GPT-4.1 | 51.52 ± 4 | 19.3 ± 3.16 | 26.67 ± 0 | 30.22 ± 0.89 | 24 | 2025-08-15 | ✓ | ✓ |
| [ML-Master](https://github.com/zeroxleo/ML-Master) deepseek-r1 | 48.5 ± 1.5 | 20.2 ± 2.3 | 24.4 ± 2.2| 29.3 ± 0.8 | 12 | 2025-06-17 | ✓ | ✓ |
| [R&D-Agent](https://github.com/microsoft/RD-Agent) o1-preview | 48.18 ± 1.1 | 8.95 ± 1.05 | 18.67 ± 1.33 | 22.4 ± 0.5 | 24 | 2025-05-14 | ✓ | ✓ |
| AIDE o1-preview | 34.3 ± 2.4 | 8.8 ± 1.1 | 10.0 ± 1.9 | 16.9 ± 1.1 | 24 | 2024-10-08 | ✓ | ✓ |
| AIDE gpt-4o-2024-08-06 | 19.0 ± 1.3 | 3.2 ± 0.5 | 5.6 ± 1.0 | 8.6 ± 0.5 | 24 | 2024-10-08 | ✓ | ✓ |
| AIDE claude-3-5-sonnet-20240620 | 19.4 ± 4.9 | 2.6 ± 1.5 | 2.3 ± 2.3 | 7.5 ± 1.8 | 24 | 2024-10-08 | ✓ | ✓ |
| OpenHands gpt-4o-2024-08-06 | 11.5 ± 3.4 | 2.2 ± 1.3 | 1.9 ± 1.9 | 5.1 ± 1.3 | 24 | 2024-10-08 | ✓ | ✓ |
| AIDE llama-3.1-405b-instruct | 8.3 ± 2.6 | 1.2 ± 0.8 | 0.0 ± 0.0 | 3.1 ± 0.9 | 24 | 2024-10-08 | ✓ | ✓ |
| MLAB gpt-4o-2024-08-06 | 4.2 ± 1.5 | 0.0 ± 0.0 | 0.0 ± 0.0 | 1.3 ± 0.5 |  24 | 2024-10-08 | ✓ | ✓ |

We appreciate the opportunity to contribute to MLE-Bench and hope that our results will be beneficial for the community. We are looking forward to your feedback and hope to merge this pull request soon.

Best regards,

The R&D-Agent Team (Microsoft Research)