### PR TITLE
Catalogue hubmap kidney segmentation test leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ catalogued below:
 - **smartphone-decimeter-2022**: The public test `span_log.nmea` files leak
   information that makes achieving a perfect score trivial.
   [#93](https://github.com/openai/mle-bench/issues/93)
+- **hubmap-kidney-segmentation**: The public test `{image_id}.json` files leak
+  information that makes achieving a close-to-perfect score trivial. They should
+  be removed.
 
 ## Authors
 


### PR DESCRIPTION
The prepare.py script for `hubmap-kidney-segmenation` incorrectly copies over {image_id}.json files to the public test set. These files are not needed and leak the test labels.