### PR TITLE
Tabular leaderboard and Upgini+MLZero tabular submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 | [R&D-Agent](https://github.com/microsoft/RD-Agent) | o3 + GPT-4.1 | 51.52 ± 4 | 19.3 ± 3.16 | 26.67 ± 0 | 30.22 ± 0.89 | 24 | 2025-08-15 | ✓ | ✓ |
 | [ML-Master](https://github.com/zeroxleo/ML-Master) | deepseek-r1 | 48.5 ± 1.5 | 20.2 ± 2.3 | 24.4 ± 2.2| 29.3 ± 0.8 | 12 | 2025-06-17 | ✓ | ✓ |
 | [R&D-Agent](https://github.com/microsoft/RD-Agent) | o1-preview | 48.18 ± 1.1 | 8.95 ± 1.05 | 18.67 ± 1.33 | 22.4 ± 0.5 | 24 | 2025-05-14 | ✓ | ✓ |
+| [MLZero](https://github.com/autogluon/autogluon-assistant) | claude-3.7-sonnet | 38.1 ± 0.0 | - | - | 10.66 ± 0.0 | 24 | 2025-05-20 | X [^2] | X |
 | AIDE | o1-preview | 34.3 ± 2.4 | 8.8 ± 1.1 | 10.0 ± 1.9 | 16.9 ± 1.1 | 24 | 2024-10-08 | ✓ | ✓ |
 | AIDE | gpt-4o-2024-08-06 | 19.0 ± 1.3 | 3.2 ± 0.5 | 5.6 ± 1.0 | 8.6 ± 0.5 | 24 | 2024-10-08 | ✓ | ✓ |
 | AIDE | claude-3-5-sonnet-20240620 | 19.4 ± 4.9 | 2.6 ± 1.5 | 2.3 ± 2.3 | 7.5 ± 1.8 | 24 | 2024-10-08 | ✓ | ✓ |
@@ -26,6 +27,34 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 
 [^1]: With some light assistance from an ensemble of models including
     Gemini-2.5-Pro, Grok-4, and Claude 4.1 Opus, distilled by Gemini-2.5-Pro.
+[^2]: Results taken from the [MLZero paper](https://arxiv.org/pdf/2505.13941)
+
+### Tabular Leaderbord (Lite Split)
+
+The table below summarizes the tabular competition rankings for the Lite complexity split. The score used is mean across scores normalized between sample submission score and the gold medal score.
+
+| Agent | LLM(s) used | Mean Normalized Score |
+| --- | --- | --- |
+| [FM Agent](https://github.com/baidubce/FM-Agent) | Gemini-2.5-Pro | 0.944 ± 0.103 |
+| [Upgini](https://github.com/upgini/upgini) + [MLZero](https://github.com/upgini/autogluon-assistant) [^3] | o3-mini | 0.927 ± 0.086 |
+| [MLZero](https://github.com/autogluon/autogluon-assistant) | o3-mini | 0.926 ± 0.088 |
+| [Thesis](https://thesislabs.ai) | gpt-5-codex | 0.891 ± 0.150 |
+| AIDE | claude-3-5-sonnet-20240620 | 0.874 ± 0.142 |
+| AIDE | gpt-4o-2024-08-06 | 0.857 ± 0.145 |
+| [R&D-Agent](https://github.com/microsoft/RD-Agent) | o1-preview | 0.818 ± 0.306 |
+| [R&D-Agent](https://github.com/microsoft/RD-Agent) | o3 + GPT-4.1 | 0.793 ± 0.371 |
+| AIDE | o1-preview | 0.783 ± 0.421 |
+| [Operand](https://operand.com) ensemble | gpt-5 (low verbosity/effort) | 0.780 ± 0.282 |
+| [Neo](https://heyneo.so/) multi-agent | undisclosed | 0.723 ± 0.483 |
+| [R&D-Agent](https://github.com/microsoft/RD-Agent) | gpt-5 | 0.497 ± 0.574 |
+| [InternAgent](https://github.com/Alpha-Innovator/InternAgent/) | deepseek-r1 | 0.048 ± 1.841 |
+| AIDE | llama-3.1-405b-instruct | 0.041 ± 1.603 |
+| [ML-Master](https://github.com/zeroxleo/ML-Master) | deepseek-r1 | -10.396 ± 22.766 |
+| [CAIR](https://research.google/teams/cloud-ai-research/) MLE-STAR-Pro | Gemini-2.5-Pro | -12.560 ± 27.105 |
+| OpenHands | gpt-4o-2024-08-06 | -17.743 ± 36.238 |
+| MLAB | gpt-4o-2024-08-06 | -1083553262524.917 ± 2167106525049.096 |
+
+[^3]: A fork with added integration with Upgini in the data processing step
 
 ## Benchmarking
 
@@ -146,6 +175,16 @@ mlebench grade-sample <PATH_TO_SUBMISSION> spaceship-titanic
 ```
 
 See more information by running `mlebench grade-sample --help`.
+
+## Ranking across competition categories
+
+It's possible to rank existing results for a particular split and competition category. For this, you can run:
+
+```console
+mlebench rank  --split-type <split type> --competition-category <category>
+```
+
+This saves normalized scores for each competition plus overall ranking in separate files. See more information by running `mlebench rank --help`.
 
 ## Environment
 

--- a/mlebench/rank.py
+++ b/mlebench/rank.py
@@ -1,0 +1,297 @@
+import json
+import re
+from logging import Logger
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+from mlebench.utils import get_logger, read_csv
+
+logger = get_logger(__name__)
+
+
+def _safe_path_component(value: str) -> str:
+    cleaned = value.strip()
+    cleaned = re.sub(r"\s+", "_", cleaned)
+    cleaned = re.sub(r"[^\w\-\.]", "-", cleaned)
+    return cleaned.lower()
+
+
+def load_competitions(
+    split_type: str,
+    competition_category: str,
+    splits_dir: Path,
+    competition_categories_path: Path,
+    logger: Logger,
+) -> List[str]:
+    """Load competition IDs filtered by split and competition category."""
+    split_file = splits_dir / f"{split_type}.txt"
+
+    if not split_file.exists():
+        logger.error(f"Split file not found for split '{split_type}': {split_file}")
+        return []
+
+    split_competitions = [
+        line.strip()
+        for line in split_file.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+    if len(split_competitions) == 0:
+        logger.warning(f"No competitions listed in split file: {split_file}")
+
+    competition_categories = read_csv(competition_categories_path)
+
+    if competition_categories.empty:
+        logger.error(f"Competition categories file is empty: {competition_categories_path}")
+        return []
+
+    competition_categories["category"] = competition_categories["category"].astype(str).str.strip()
+    category_filter = (
+        competition_categories["category"].str.casefold() == competition_category.strip().casefold()
+    )
+    category_competitions = set(
+        competition_categories.loc[category_filter, "competition_id"].dropna().astype(str)
+    )
+
+    if len(category_competitions) == 0:
+        logger.error(
+            f"No competitions found with category '{competition_category}' in {competition_categories_path}"
+        )
+        return []
+
+    competitions = [
+        competition_id
+        for competition_id in split_competitions
+        if competition_id in category_competitions
+    ]
+
+    if len(competitions) == 0:
+        logger.warning(
+            f"No competitions from split '{split_type}' match category '{competition_category}'. "
+            "Check split and category configuration."
+        )
+
+    logger.info(
+        f"Loaded {len(competitions)} competitions for split '{split_type}' and category '{competition_category}'."
+    )
+
+    return competitions
+
+
+def get_competition_results(
+    competition_id: str, runs_dir: Path, experiment_groups: pd.DataFrame, logger: Logger
+) -> pd.DataFrame | None:
+    """Collect all results for a specific competition across all run groups."""
+    results = []
+
+    # Get unique run groups from experiment_groups
+    run_groups = experiment_groups["run_group"].unique()
+
+    for run_group in run_groups:
+        run_group_dir = runs_dir / run_group
+        if not run_group_dir.exists() or not run_group_dir.is_dir():
+            continue
+
+        # Find grading report files
+        grading_reports = sorted(list(run_group_dir.glob("*grading_report*.json")))
+        if len(grading_reports) == 0:
+            continue
+
+        # Load the latest grading report
+        latest_report = grading_reports[-1]
+        data = json.loads(latest_report.read_text())
+
+        reports = data.get("competition_reports", [])
+        if isinstance(reports, dict):
+            reports = [reports]
+
+        for report in reports:
+            if report.get("competition_id") == competition_id:
+                report["run_group"] = run_group
+                results.append(report)
+                break
+
+    if len(results) == 0:
+        logger.warning(f"No results found for competition: {competition_id}")
+        return None
+
+    results_df = pd.DataFrame(results)
+
+    # Merge with experiment groups
+    results_df = results_df.merge(experiment_groups, how="left", on="run_group")
+
+    return results_df
+
+
+def load_sample_reports(sample_report_path: Path, logger: Logger) -> dict[str, dict]:
+    sample_reports: dict[str, dict] = {}
+    if not sample_report_path.exists():
+        logger.warning(f"Sample grading report not found at {sample_report_path}")
+        return sample_reports
+    try:
+        sample_data = json.loads(sample_report_path.read_text())
+    except json.JSONDecodeError as exc:
+        logger.error(f"Failed to parse sample grading report at {sample_report_path}: {exc}")
+        return sample_reports
+
+    sample_competitions = sample_data.get("competition_reports", [])
+    if isinstance(sample_competitions, dict):
+        sample_competitions = [sample_competitions]
+
+    for report in sample_competitions:
+        competition_id = report.get("competition_id")
+        if competition_id:
+            sample_reports[competition_id] = report
+    return sample_reports
+
+
+def score_competition_results(
+    competition_id: str,
+    results_df: pd.DataFrame,
+    sample_reports: dict[str, dict],
+    logger: Logger,
+) -> pd.DataFrame:
+    sample_report = sample_reports.get(competition_id)
+    sample_score = sample_report.get("score") if sample_report else None
+    sample_gold = sample_report.get("gold_threshold") if sample_report else None
+    denominator: float | None = None
+    if sample_score is not None and sample_gold is not None:
+        denominator = sample_score - sample_gold
+        if denominator == 0:
+            logger.warning(
+                "Sample submission score equals gold threshold for %s; normalized scores unavailable.",
+                competition_id,
+            )
+            denominator = None
+    else:
+        logger.warning(
+            "Missing sample submission baseline for %s; normalized scores unavailable.",
+            competition_id,
+        )
+
+    if denominator is not None:
+        results_df["normalized_score"] = (sample_score - results_df["score"]) / denominator
+    else:
+        results_df["normalized_score"] = pd.NA
+
+    stats_df = results_df.groupby("experiment_id", group_keys=True).agg(
+        mean_score=("score", "mean"),
+        std_score=("score", "std"),
+        n_runs=("score", "count"),
+        mean_normalized_score=("normalized_score", "mean"),
+        std_normalized_score=("normalized_score", "std"),
+    )
+    stats_df = stats_df.reset_index()
+
+    stats_df = stats_df.sort_values(
+        "mean_normalized_score", ascending=False, na_position="last"
+    ).reset_index(drop=True)
+
+    return stats_df
+
+
+def aggregate_scores(rank_series_list: list[pd.Series]) -> pd.DataFrame | None:
+    if len(rank_series_list) == 0:
+        return None
+    rank_df = pd.concat(rank_series_list, axis=1).fillna(0)
+    rank_df = rank_df.agg(["mean", "std"], axis=1)
+    rank_df.columns = ["mean_normalized_score", "std_normalized_score"]
+    return rank_df
+
+
+def collect_rankings(
+    run_group_experiments_path: Path,
+    runs_dir: Path,
+    splits_dir: Path,
+    competition_categories_path: Path,
+    split_type: str,
+    competition_category: str,
+    experiment_agents_path: Path,
+    output_dir: Path,
+    sample_report_path: Path,
+):
+    sample_reports = load_sample_reports(sample_report_path, logger)
+
+    # Load competitions from configured split and category
+    competitions = load_competitions(
+        split_type=split_type,
+        competition_category=competition_category,
+        splits_dir=splits_dir,
+        competition_categories_path=competition_categories_path,
+        logger=logger,
+    )
+
+    if len(competitions) == 0:
+        logger.error("No competitions available to process. Exiting.")
+        return
+    logger.info(f"Competitions to evaluate: {competitions}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    split_dirname = _safe_path_component(split_type)
+    category_dirname = _safe_path_component(competition_category)
+    competition_results_dir = output_dir / split_dirname / category_dirname / "competition_results"
+    competition_results_dir.mkdir(parents=True, exist_ok=True)
+    base_output_dir = competition_results_dir.parent
+
+    logger.info(f"Writing results under {base_output_dir}")
+
+    # Read experiment to run_group mapping
+    experiment_groups = read_csv(run_group_experiments_path)
+    logger.info(f"Found {len(experiment_groups)} experiment-run_group mappings")
+
+    # Read experiment agents mapping
+    experiment_agents = read_csv(experiment_agents_path)
+    logger.info(f"Found {len(experiment_agents)} experiment-agent mappings")
+
+    # Collect results for each tabular competition
+    rank_series_list: list[pd.Series] = []
+
+    for competition_id in competitions:
+        logger.info(f"Processing competition: {competition_id}")
+        results_df = get_competition_results(competition_id, runs_dir, experiment_groups, logger)
+
+        if results_df is None or len(results_df) == 0:
+            logger.warning(f"No results for {competition_id}")
+            continue
+
+        # Filter to only valid scores
+        results_df = results_df[results_df["score"].notna()].copy()
+
+        if len(results_df) == 0:
+            logger.warning(f"No valid scores for {competition_id}")
+            continue
+
+        stats_df = score_competition_results(competition_id, results_df, sample_reports, logger)
+
+        # Save per-competition CSV (without agent descriptions)
+        competition_output = competition_results_dir / f"{competition_id}.csv"
+        stats_df.to_csv(competition_output, index=False)
+        logger.info(f"Saved results for {competition_id} to {competition_output}")
+
+        # Collect ranks for overall ranking
+        rank_series_list.append(
+            stats_df.set_index("experiment_id")["mean_normalized_score"].rename(competition_id)
+        )
+
+    # Create overall score DataFrame
+    rank_df = aggregate_scores(rank_series_list)
+    if rank_df is None:
+        logger.error("No scores collected for any competition!")
+        return
+
+    # Create final results DataFrame
+    final_results = rank_df.reset_index()
+    final_results = final_results.merge(experiment_agents, on="experiment_id", how="left")
+
+    # Sort by mean_rank
+    final_results = final_results.sort_values("mean_normalized_score", ascending=False).reset_index(
+        drop=True
+    )
+
+    # Save final mean ranks CSV
+    final_output = base_output_dir / "overall_ranks.csv"
+    final_results.to_csv(final_output, index=False)
+    logger.info(f"Saved final ranking to {final_output}")

--- a/rankings/low/tabular/competition_results/new-york-city-taxi-fare-prediction.csv
+++ b/rankings/low/tabular/competition_results/new-york-city-taxi-fare-prediction.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a76406c16e2501aa78d15dd5987f5408f807a058f47a4cbeeed53a6e2ed1870
+size 1716

--- a/rankings/low/tabular/competition_results/nomad2018-predict-transparent-conductors.csv
+++ b/rankings/low/tabular/competition_results/nomad2018-predict-transparent-conductors.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebeedfd795e6f5cdcd1e54d09645347820ab5f832dde6b2c71bd01f87c0deda6
+size 2141

--- a/rankings/low/tabular/competition_results/tabular-playground-series-dec-2021.csv
+++ b/rankings/low/tabular/competition_results/tabular-playground-series-dec-2021.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e8494b6dc33e566ec5151b74eed11fa6568efdc4bd70e13c2cf4e1f6e5ca237
+size 2076

--- a/rankings/low/tabular/competition_results/tabular-playground-series-may-2022.csv
+++ b/rankings/low/tabular/competition_results/tabular-playground-series-may-2022.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98221d3960a4cfee769de59749beb3020c3e7c164317e1f0d52c7237c321574b
+size 1813

--- a/rankings/low/tabular/overall_ranks.csv
+++ b/rankings/low/tabular/overall_ranks.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91b67c36c5a77a107a4480819b29e83fe825a960c80f5c8f978f335e7faac961
+size 2413

--- a/runs/README.md
+++ b/runs/README.md
@@ -48,3 +48,5 @@ table below.
 | MLE-STAR-Pro                    | CAIR MLE-STAR-Pro, 12 hours, 24 vCPUs, 220GB of RAM, and 1 V100 GPU          |
 | AIRA-dojo | o3 on on AIRA-DOJO Greedy scaffolding , 24 hours, 24 vCPUs, 120GB of RAM and 1 H200 GPU |
 | thesis | gpt-5-codex yc sprint on custom scaffolding , 24 hours, 24 vCPUs, 170GB of RAM and 1 H100 GPU |
+| o3-mini-MLZero | o3-mini on MLZero (AutoGluon Assistant), 2 hours, 32 vCPUs, 128GB of RAM |
+| o3-mini-Upgini-MLZero | o3-mini on MLZero (AutoGluon Assistant) with Upgini feature enrichment,  2 hours, 32 vCPUs, 128GB of RAM |

--- a/runs/experiment_agents.csv
+++ b/runs/experiment_agents.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7966d13994f429e262d32cab573740e42d3713675535a88df399f1609d6cab1
+size 1625

--- a/runs/mlzero-o3mini-group1/grading_report_group_1.json
+++ b/runs/mlzero-o3mini-group1/grading_report_group_1.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e854d5b6a70fc20c38ed20bbb2b3a688a98ba3c39460dd98dd2518de5fe9d6d
+size 3352

--- a/runs/mlzero-o3mini-group2/grading_report_group_2.json
+++ b/runs/mlzero-o3mini-group2/grading_report_group_2.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f207a23db42b5b67edda496abaa6139a7248cf6e1573037372bb672d1b0fbd1d
+size 2916

--- a/runs/mlzero-o3mini-group3/grading_report_group_3.json
+++ b/runs/mlzero-o3mini-group3/grading_report_group_3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:affd70124abd563bcc35e76789238adcbb2a6695df80fbcc0df2327f935374e5
+size 3352

--- a/runs/run_group_experiments.csv
+++ b/runs/run_group_experiments.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19744451e9e00efa89acd3a52dfe63845e8c2c2b1bb4d5c1050a87ec0c9f02a5
-size 4540
+oid sha256:4fd24fa957d79fc7725ab3f4f7f60ec3bf9a7074ebb1b96db573f786ea9268f0
+size 4798

--- a/runs/sample-submissions/grading_report.json
+++ b/runs/sample-submissions/grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcb803d6b0702442c290a2c02ee921a89758f7734f9720be696a1da214ef2bb0
+size 3385

--- a/runs/upgini-mlzero-o3mini-group1/grading_report_group_1.json
+++ b/runs/upgini-mlzero-o3mini-group1/grading_report_group_1.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ace13cb548e2b159bf957eee12e68b1fa09cc7b63d9e68c2f94b894317ac0a9
+size 2917

--- a/runs/upgini-mlzero-o3mini-group2/grading_report_group_2.json
+++ b/runs/upgini-mlzero-o3mini-group2/grading_report_group_2.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48f736fa8c07e72fb66fd026c5bee835177761f03f7aad13bdad27a443765fc7
+size 3350

--- a/runs/upgini-mlzero-o3mini-group3/grading_report_group_3.json
+++ b/runs/upgini-mlzero-o3mini-group3/grading_report_group_3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a727671b0295e1cbdff86bb1fad7998cf5b7a09ee4e47866d7293ec792d63fd2
+size 3352


### PR DESCRIPTION
Hello,

We're [Upgini](https://github.com/upgini/upgini), and we're dedicated to enhancing AI from data perspective. We believe AI agents are the future. However, upon inspecting mle-bench, we found out that the leaderboard across tabular datasets is drastically different from the one based on overall medal scores. Since many of real-world problems are still tabular, we think it's an important point to consider when evaluating agent performance.

We've implemented a convenience command that computes normalized score (like the one you were using for the analysis in your paper) across splits and competition categories. We also include our results for tabular datasets in conjunction with [MLZero](https://github.com/autogluon/autogluon-assistant) agent aka AutoGluon Assistant. We include results from their paper in the main leaderboard.

For the Upgini+MLZero runs we used our [integration fork](https://github.com/upgini/autogluon-assistant). We used o3-mini with 32 CPU and 128 GB RAM. The time limit for a dataset was set to 24 hours, although each run completed in under 2 hours.

Please let us know if you have any questions!