### PR TITLE
docs: Add links to aideml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 | [R&D-Agent](https://github.com/microsoft/RD-Agent) | o3 + GPT-4.1 | 51.52 ± 4 | 19.3 ± 3.16 | 26.67 ± 0 | 30.22 ± 0.89 | 24 | 2025-08-15 | ✓ | ✓ |
 | [ML-Master](https://github.com/zeroxleo/ML-Master) | deepseek-r1 | 48.5 ± 1.5 | 20.2 ± 2.3 | 24.4 ± 2.2| 29.3 ± 0.8 | 12 | 2025-06-17 | ✓ | ✓ |
 | [R&D-Agent](https://github.com/microsoft/RD-Agent) | o1-preview | 48.18 ± 1.1 | 8.95 ± 1.05 | 18.67 ± 1.33 | 22.4 ± 0.5 | 24 | 2025-05-14 | ✓ | ✓ |
-| AIDE | o1-preview | 34.3 ± 2.4 | 8.8 ± 1.1 | 10.0 ± 1.9 | 16.9 ± 1.1 | 24 | 2024-10-08 | ✓ | ✓ |
-| AIDE | gpt-4o-2024-08-06 | 19.0 ± 1.3 | 3.2 ± 0.5 | 5.6 ± 1.0 | 8.6 ± 0.5 | 24 | 2024-10-08 | ✓ | ✓ |
-| AIDE | claude-3-5-sonnet-20240620 | 19.4 ± 4.9 | 2.6 ± 1.5 | 2.3 ± 2.3 | 7.5 ± 1.8 | 24 | 2024-10-08 | ✓ | ✓ |
+| [AIDE](https://github.com/wecoai/aideml) | o1-preview | 34.3 ± 2.4 | 8.8 ± 1.1 | 10.0 ± 1.9 | 16.9 ± 1.1 | 24 | 2024-10-08 | ✓ | ✓ |
+| [AIDE](https://github.com/wecoai/aideml) | gpt-4o-2024-08-06 | 19.0 ± 1.3 | 3.2 ± 0.5 | 5.6 ± 1.0 | 8.6 ± 0.5 | 24 | 2024-10-08 | ✓ | ✓ |
+| [AIDE](https://github.com/wecoai/aideml) | claude-3-5-sonnet-20240620 | 19.4 ± 4.9 | 2.6 ± 1.5 | 2.3 ± 2.3 | 7.5 ± 1.8 | 24 | 2024-10-08 | ✓ | ✓ |
 | OpenHands | gpt-4o-2024-08-06 | 11.5 ± 3.4 | 2.2 ± 1.3 | 1.9 ± 1.9 | 5.1 ± 1.3 | 24 | 2024-10-08 | ✓ | ✓ |
-| AIDE | llama-3.1-405b-instruct | 8.3 ± 2.6 | 1.2 ± 0.8 | 0.0 ± 0.0 | 3.1 ± 0.9 | 24 | 2024-10-08 | ✓ | ✓ |
+| [AIDE](https://github.com/wecoai/aideml) | llama-3.1-405b-instruct | 8.3 ± 2.6 | 1.2 ± 0.8 | 0.0 ± 0.0 | 3.1 ± 0.9 | 24 | 2024-10-08 | ✓ | ✓ |
 | MLAB | gpt-4o-2024-08-06 | 4.2 ± 1.5 | 0.0 ± 0.0 | 0.0 ± 0.0 | 1.3 ± 0.5 |  24 | 2024-10-08 | ✓ | ✓ |
 
 [^1]: With some light assistance from an ensemble of models including


### PR DESCRIPTION
Hello MLE-Bench authors,

Congrats on the popularity of mle-bench — it’s a fantastic resource. We open-sourced AIDE from the start, and we understand AIDE serves as a baseline that other frameworks test against. We’d like to add a link to our original AIDE implementation so users can easily find it:

AIDE original implementation: https://github.com/wecoai/aideml
AIDE paper: https://arxiv.org/abs/2502.13138

Thanks for the great work!

Best regards,
Weco AI Team