### PR TITLE
Add ML-Master 2.0 results

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 
 | Agent | LLM(s) used | Low == Lite (%) | Medium (%) | High (%) | All (%) | Running Time (hours) | Date | Grading Reports Available | Source Code Available |
 |-------|-------------|-----------------|------------|----------|---------|----------------------|------|---------------------------|----------------------|
+| [ML-Master 2.0](https://github.com/sjtu-sai-agents/ML-Master) | Deepseek-V3.2-Speciale | 75.76 ± 1.51 | 50.88 ± 3.51 | 42.22 ± 2.22 | 56.44 ± 2.47 | 24 | 2025-12-16 | ✓ | X |
 | [Leeroo](https://leeroo.com/) | Gemini-3-Pro-Preview[^3] | 68.18 ± 2.62[^2] | 44.74 ± 1.52[^2] | 40.00 ± 0.00[^2] | 50.67 ± 1.33[^2] | 24 | 2025-12-07 | ✓ | X |
 | [Thesis](https://thesislabs.ai) | gpt-5-codex | 65.15 ± 1.52 | 45.61 ± 7.18 | 31.11 ± 2.22 | 48.44 ± 3.64 | 24 | 2025-11-10 | ✓ | X |
 | [CAIR](https://research.google/teams/cloud-ai-research/) MLE-STAR-Pro-1.5 | Gemini-2.5-Pro | 68.18 ± 2.62 | 34.21 ± 1.52  |  33.33 ±  0.00 |  44.00 ± 1.33 | 24 | 2025-11-25 | ✓ | X |

--- a/runs/README.md
+++ b/runs/README.md
@@ -50,3 +50,4 @@ table below.
 | AIRA-dojo | o3 on on AIRA-DOJO Greedy scaffolding , 24 hours, 24 vCPUs, 120GB of RAM and 1 H200 GPU |
 | thesis | gpt-5-codex yc sprint on custom scaffolding , 24 hours, 24 vCPUs, 170GB of RAM and 1 H100 GPU |
 | Leeroo | Ensemble (Gemini-3-Pro-Preview, GPT-5, GPT-5-mini) 24 hours, 24 vCPUs, 150GB of RAM and 1 H100 GPU |
+| ML-Master-2.0                       | Deepseek-V3.2-Speciale on ML-Master-2.0 scaffolding, 24 hours, 36 vCPUs, 252GB of RAM and 2 x 4090-24GB GPU|

--- a/runs/mlmaster_group4/grading_report_group_4.json
+++ b/runs/mlmaster_group4/grading_report_group_4.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb5418ca7dcfae88851fd7b53182521b89f13736ae61afec5095dfe896b8a77e
+size 50745

--- a/runs/mlmaster_group5/grading_report_group_5.json
+++ b/runs/mlmaster_group5/grading_report_group_5.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95ce6744125f022408b73072e4be73f5e32f91de362fe80fceaa45e2797ea355
+size 50762

--- a/runs/mlmaster_group6/grading_report_group_6.json
+++ b/runs/mlmaster_group6/grading_report_group_6.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e825bec59ab003228341344aa38129c0f7bfed66b9d41b4eb1032a2da77956d
+size 50752

--- a/runs/run_group_experiments.csv
+++ b/runs/run_group_experiments.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c6d0763e304796a8aa5dfb710a12d7a09cfa8ea8c80a7ec638137b3e17057a4
-size 4726
+oid sha256:d4c85f9d3ac9aff0146e59e1c785bdc50ba96cf77df511fda8265f54335b7143
+size 4885


### PR DESCRIPTION
Hello MLE-Bench team,

We are the ML-Master team from Shanghai Jiao Tong University. In the past few months, we have continued our research following ML-Master and would like to share the results of our latest version, **ML-Master 2.0**.

Our latest experiments indicate that ML-Master 2.0 has achieved improved performance across the benchmark tasks. We hope these results can contribute to the community's understanding of agent capabilities in machine learning engineering and our paper is coming soon.

As part of this pull request, we provide:

* **Detailed grade reports:** Located in `mle-bench/runs/mlmaster_group[4-6]`, containing three independent runs (seeds) per competition.
* **Results summary:** A table updating our performance metrics alongside existing benchmarks for reference.
* **Run visualization:** An updated interactive webpage to explore the code solution by ML-Master 2.0:  [https://sjtu-sai-agents.github.io/ML-Master](https://sjtu-sai-agents.github.io/ML-Master)



### Resources Used
* For each run, we used 36 vCPUs, 252GB of RAM, and two 4090-24GB GPU with a time limit of 24 hours.


### Updated Results Table

The following table summarizes the average performance of ML-Master-2.0 compared to the currently reported methods.

| Agent | LLM(s) used | Low == Lite (%) | Medium (%) | High (%) | All (%) | Running Time (hours) | Date | Grading Reports Available | Source Code Available |
|-------|-------------|-----------------|------------|----------|---------|----------------------|------|---------------------------|----------------------|
| [ML-Master 2.0](https://github.com/sjtu-sai-agents/ML-Master) | Deepseek-V3.2-Speciale | 75.76 ± 1.51 | 50.88 ± 3.51 | 42.22 ± 2.22 | 56.44 ± 2.47 | 24 | 2025-12-16 | ✓ | X |
| [Leeroo](https://leeroo.com/) | Gemini-3-Pro-Preview | 68.18 ± 2.62 | 44.74 ± 1.52 | 40.00 ± 0.00 | 50.67 ± 1.33 | 24 | 2025-12-07 | ✓ | X |
| [Thesis](https://thesislabs.ai) | gpt-5-codex | 65.15 ± 1.52 | 45.61 ± 7.18 | 31.11 ± 2.22 | 48.44 ± 3.64 | 24 | 2025-11-10 | ✓ | X |
| [CAIR](https://research.google/teams/cloud-ai-research/) MLE-STAR-Pro-1.5 | Gemini-2.5-Pro | 68.18 ± 2.62 | 34.21 ± 1.52  |  33.33 ±  0.00 |  44.00 ± 1.33 | 24 | 2025-11-25 | ✓ | X |
| [FM Agent](https://github.com/baidubce/FM-Agent) | Gemini-2.5-Pro | 62.12 ± 1.52 | 36.84 ± 1.52 | 33.33 ± 0.00 | 43.56 ± 0.89 | 24 | 2025-10-10 | ✓ | X |
| [Operand](https://operand.com) ensemble | gpt-5 (low verbosity/effort) | 63.64 ± 0.00 | 33.33 ± 0.88 | 20.00 ± 0.00 | 39.56 ± 0.44 | 24 | 2025-10-06 | ✓ | X |
| [CAIR](https://research.google/teams/cloud-ai-research/) MLE-STAR-Pro-1.0 | Gemini-2.5-Pro | 66.67 ± 1.52  | 25.44  ±  0.88 | 31.11 ± 2.22  | 38.67 ± 0.77 | 12 | 2025-11-03 | ✓ | X |
| [InternAgent](https://github.com/Alpha-Innovator/InternAgent/) | deepseek-r1 | 62.12 ± 3.03 | 26.32 ± 2.63 | 24.44 ± 2.22| 36.44 ± 1.18 | 12 | 2025-09-12 | ✓ | X |
| [R&D-Agent](https://github.com/microsoft/RD-Agent) | gpt-5 | 68.18 ± 2.62 | 21.05 ± 1.52 | 22.22 ± 2.22 | 35.11 ± 0.44 | 12 | 2025-09-26 | ✓ | ✓ |
| [Neo](https://heyneo.so/) multi-agent | undisclosed | 48.48 ± 1.52 | 29.82 ± 2.32 | 24.44 ± 2.22 | 34.22 ± 0.89 | 36 | 2025-07-28 | ✓ | X |
| [AIRA-dojo](https://github.com/facebookresearch/aira-dojo/) | o3 | 55.00 ± 1.47 | 21.97 ± 1.17 | 21.67 ± 1.07 | 31.60 ± 0.82 | 24 | 2025-05-15 | ✓ | ✓ |
| [R&D-Agent](https://github.com/microsoft/RD-Agent) | o3 + GPT-4.1 | 51.52 ± 4.01 | 19.30 ± 3.16 | 26.67 ± 0.00 | 30.22 ± 0.89 | 24 | 2025-08-15 | ✓ | ✓ |
| [ML-Master](https://github.com/sjtu-sai-agents/ML-Master) | deepseek-r1 | 48.48 ± 1.52 | 20.18 ± 2.32 | 24.44 ± 2.22 | 29.33 ± 0.77 | 12 | 2025-06-17 | ✓ | ✓ |
| [R&D-Agent](https://github.com/microsoft/RD-Agent) | o1-preview | 48.18 ± 1.11 | 8.95 ± 1.05 | 18.67 ± 1.33 | 22.40 ± 0.50 | 24 | 2025-05-14 | ✓ | ✓ |
| [AIDE](https://github.com/wecoai/aideml) | o1-preview | 35.91 ± 1.86 | 8.45 ± 0.43 | 11.67 ± 1.27 | 17.12 ± 0.61 | 24 | 2024-10-08 | ✓ | ✓ |
| [AIDE](https://github.com/wecoai/aideml) | gpt-4o-2024-08-06 | 18.55 ± 1.26 | 3.06 ± 0.33 | 8.15 ± 0.84 | 8.63 ± 0.54 | 24 | 2024-10-08 | ✓ | ✓ |
| [AIDE](https://github.com/wecoai/aideml) | claude-3-5-sonnet-20240620 | 19.70 ± 1.52 | 2.63 ± 1.52 | 2.22 ± 2.22 | 7.56 ± 1.60 | 24 | 2024-10-08 | ✓ | ✓ |
| OpenHands | gpt-4o-2024-08-06 | 12.12 ± 1.52 | 1.75 ± 0.88 | 2.22 ± 2.22 | 4.89 ± 0.44 | 24 | 2024-10-08 | ✓ | ✓ |
| [AIDE](https://github.com/wecoai/aideml) | llama-3.1-405b-instruct | 10.23 ± 1.14 | 0.66 ± 0.66 | 0.00 ± 0.00 | 3.33 ± 0.38 | 24 | 2024-10-08 | ✓ | ✓ |
| MLAB | gpt-4o-2024-08-06 | 4.55 ± 0.86 | 0.00 ± 0.00 | 0.00 ± 0.00 | 1.60 ± 0.27 | 24 | 2024-10-08 | ✓ | ✓ |

We appreciate the robust ecosystem MLE-Bench provides and the ongoing efforts to enhance its capabilities. We hope these results will be a valuable addition and welcome your feedback on this submission. Please let us know if any improvements are needed before merging.

Best regards,

The ML-Master Team (Shanghai Jiao Tong University)
