### PR TITLE
Add source code link for Leeroo submission (Open Source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 | [Famou-Agent 2.0](https://github.com/baidubce/FM-Agent) | Gemini-2.5-Pro | 75.76 ± 1.52 | 57.89 ± 1.52 | 40.00 ± 0.00 | 59.56 ± 0.89 | 24 | 2025-12-27 | ✓ | X |
 | [ML-Master 2.0](https://github.com/sjtu-sai-agents/ML-Master) | Deepseek-V3.2-Speciale | 75.76 ± 1.51 | 50.88 ± 3.51 | 42.22 ± 2.22 | 56.44 ± 2.47 | 24 | 2025-12-16 | ✓ | X |
 |[PiEvolve](https://github.com/FractalAIResearchLabs/PiEvolve)<br>(Fractal AI Research)|Gemini-3-Pro-Preview[^3]|74.24 ± 3.03[^2]|45.61 ±  0.88[^2] | 35.55 ± 2.22[^2]|52.0 ±  0.77[^2]|12|2026-01-05|✓|X|
-| [Leeroo](https://leeroo.com/) | Gemini-3-Pro-Preview[^3] | 68.18 ± 2.62[^2] | 44.74 ± 1.52[^2] | 40.00 ± 0.00[^2] | 50.67 ± 1.33[^2] | 24 | 2025-12-07 | ✓ | X |
+| [Leeroo](https://github.com/Leeroo-AI/kapso) | Gemini-3-Pro-Preview[^3] | 68.18 ± 2.62[^2] | 44.74 ± 1.52[^2] | 40.00 ± 0.00[^2] | 50.67 ± 1.33[^2] | 24 | 2025-12-07 | ✓ | ✓ |
 | [Thesis](https://thesislabs.ai) | gpt-5-codex | 65.15 ± 1.52 | 45.61 ± 7.18 | 31.11 ± 2.22 | 48.44 ± 3.64 | 24 | 2025-11-10 | ✓ | X |
 | [CAIR](https://research.google/teams/cloud-ai-research/) MLE-STAR-Pro-1.5 | Gemini-2.5-Pro | 68.18 ± 2.62 | 34.21 ± 1.52  |  33.33 ±  0.00 |  44.00 ± 1.33 | 24 | 2025-11-25 | ✓ | X |
 | [Famou-Agent](https://github.com/baidubce/FM-Agent) | Gemini-2.5-Pro | 62.12 ± 1.52 | 36.84 ± 1.52 | 33.33 ± 0.00 | 43.56 ± 0.89 | 24 | 2025-10-10 | ✓ | X |


### PR DESCRIPTION
Hi MLE-bench team!

We're excited to share that we've open-sourced the framework of Leeroo submission.

This PR updates the Leeroo leaderboard entry to include the open-source repository link.

### Changes
- Updated Leeroo agent link to point to the source code repository: https://github.com/Leeroo-AI/kapso
- Marked "Source Code Available" as ✓

KAPSO is now publicly available under MIT license.

Best,
Leeroo team