### PR TITLE
Fix missing columns in ranzcr-clip-catheter-line-classification sample submission

### DIFF
--- a/mlebench/competitions/ranzcr-clip-catheter-line-classification/classes.py
+++ b/mlebench/competitions/ranzcr-clip-catheter-line-classification/classes.py
@@ -8,4 +8,6 @@ CLASSES = [
     "NGT - Normal",
     "CVC - Abnormal",
     "CVC - Borderline",
+    "CVC - Normal",
+    "Swan Ganz Catheter Present",
 ]

--- a/mlebench/competitions/ranzcr-clip-catheter-line-classification/prepare.py
+++ b/mlebench/competitions/ranzcr-clip-catheter-line-classification/prepare.py
@@ -43,8 +43,10 @@ def prepare(raw: Path, public: Path, private: Path):
     ), f"Expected {len(new_test)} files in public test, got {len(list(public.glob('test/*.jpg')))}"
 
     # Create a sample submission file
-    submission_df = new_test[["StudyInstanceUID"] + CLASSES]
-    submission_df[CLASSES] = 0
+    # Start with StudyInstanceUID from new_test, then add all CLASSES columns
+    submission_df = new_test[["StudyInstanceUID"]].copy()
+    for class_name in CLASSES:
+        submission_df[class_name] = 0
 
     # Copy over files
     new_train.to_csv(public / "train.csv", index=False)


### PR DESCRIPTION
## Problem
The sample submission file for \anzcr-clip-catheter-line-classification\ was missing two required columns:
- \CVC - Normal\
- \Swan Ganz Catheter Present\

Additionally, the \prepare.py\ script was trying to select CLASSES columns from \	rain.csv\, but those columns don't exist there (they're in \	rain_annotations.csv\), which would cause a KeyError.

## Solution
1. Added the two missing classes to \classes.py\
2. Fixed \prepare.py\ to properly create the submission dataframe by:
   - Starting with \StudyInstanceUID\ from \
ew_test\
   - Adding each class column individually with default value 0

## Result
The sample submission file now has all 12 required columns as specified in the competition format:
- StudyInstanceUID
- All 11 class columns (including the two that were missing)

Fixes the known issue mentioned in the repository.