### PR TITLE
Add LoongFlow MLE-Bench Results (Open Source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 
 | Agent | LLM(s) used | Low == Lite (%) | Medium (%) | High (%) | All (%) | Running Time (hours) | Date | Grading Reports Available | Source Code Available |
 |-------|-------------|-----------------|------------|----------|---------|----------------------|------|---------------------------|----------------------|
+| [LoongFlow](https://github.com/baidu-baige/LoongFlow) | Gemini-3-Flash-Preview          | 77.27 ± 0.0[^2]  | 63.15 ± 1.51[^2]  |40.0 ± 0.00[^2]| 62.66 ± 0.76[^2] |24| 2026-02-09 |✓|✓|
 |[PiEvolve](https://github.com/FractalAIResearchLabs/PiEvolve)<br>(Fractal AI Research)|Gemini-3-Pro-Preview[^3]|80.30 ± 1.52[^2]|58.77 ± 0.88[^2]|40.0 ± 0.00[^2]|61.33 ± 0.77[^2]|24|2026-01-05|✓|X|
 | [Famou-Agent 2.0](https://github.com/baidubce/FM-Agent) | Gemini-2.5-Pro | 75.76 ± 1.52 | 57.89 ± 1.52 | 40.00 ± 0.00 | 59.56 ± 0.89 | 24 | 2025-12-27 | ✓ | X |
 | [ML-Master 2.0](https://github.com/sjtu-sai-agents/ML-Master) | Deepseek-V3.2-Speciale | 75.76 ± 1.51 | 50.88 ± 3.51 | 42.22 ± 2.22 | 56.44 ± 2.47 | 24 | 2025-12-16 | ✓ | X |

--- a/runs/README.md
+++ b/runs/README.md
@@ -54,3 +54,4 @@ table below.
 | Famou-Agent-2.0                       | Gemini-2.5-Pro, 24 hours, 64 vCPUs, 500GB of RAM, and 1 A800 GPU |
 | PiEvolve_24hrs                      | Gemini-3-Pro-preview, 24 hours, 40 vCPUs, 240 GB RAM, and 1 H100 GPU |
 | PiEvolve_12hrs                      | Gemini-3-Pro-preview, 12 hours, 40 vCPUs, 240 GB RAM, and 1 H100 GPU |
+| LoongFlow                           | Gemini-3-Flash-preview, 24 hours, 36 vCPUs, 440 GB RAM, and 2 x A10 GPU or 2 x H20 GPU (depending on running nodes)               |

--- a/runs/loongflow_group1/2026-02-09T07-43-11-GMT_grading_report.json
+++ b/runs/loongflow_group1/2026-02-09T07-43-11-GMT_grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18a5c703a0070cb88e965be5516a17b336b782c42411cfab44828fd4c3f960fd
+size 30035

--- a/runs/loongflow_group2/2026-02-09T07-46-10-GMT_grading_report.json
+++ b/runs/loongflow_group2/2026-02-09T07-46-10-GMT_grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6b73ea5ba74f9c8fcdcf68e284eab376c16c5e8c9a88f8f5c2fb50f3597957e
+size 29408

--- a/runs/loongflow_group3/2026-02-09T07-50-35-GMT_grading_report.json
+++ b/runs/loongflow_group3/2026-02-09T07-50-35-GMT_grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46b4cafb6dfc1e3b9106c8b38246a7401952c28cf879a5251c157090801c522
+size 28810

--- a/runs/run_group_experiments.csv
+++ b/runs/run_group_experiments.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6797d3c155bb22f59629b6c88b673f0491d2a5e2b0f7eeca403094220db14042
-size 5197
+oid sha256:6661dd852dbe97ba455d58a370b483c9a140cb77bff02e8474350c71588af718
+size 5278


### PR DESCRIPTION
Hello MLE-Bench team,

We are pleased to submit the evaluation results for **[LoongFlow](https://github.com/baidu-baige/LoongFlow)**, an open-source thinking & learning framework for expert-grade AI agents.

To promote open research and community development, we have made the full framework source code publicly available at: **[https://github.com/baidu-baige/LoongFlow](https://github.com/baidu-baige/LoongFlow)**

### Resources per run

- **Model**: gemini-3-flash-preview
- **CPU / Memory**: 36 vCPUs, 440 GB RAM
- **GPU**: 2× NVIDIA A10 or 2× NVIDIA H20 (depending on node)
- **Time Limit**: 24 hours

### Pull Request Contents

This PR updates the `README.md` leaderboard and includes detailed grading reports for three independent runs, located at:
- `runs/loongflow_group1`
- `runs/loongflow_group2`
- `runs/loongflow_group3`

**Note**: Grading was performed using the `--pad-missing` flag.

We deeply appreciate the MLE-Bench project for providing this valuable evaluation platform for ML engineering agents. We hope our open-source contribution will facilitate technical advancement and community growth in the AI Agent field.

Best regards,

The LoongFlow Team