### PR TITLE
Raise an issue for a bug in the validate_submission function

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ If you wish to make a submission to v1 in the meantime, please still include
 the following competitions in your overall scores. The known issues are
 catalogued below:
 
+- **tensorflow2-question-answering**:
+  - The `validate_submission` function in `grade.py` fails on this competition 
+    because the answer file is `test.jsonl` instead of `test.csv`.
+    [#134](https://github.com/openai/mle-bench/issues/134)
 - **tensorflow-speech-recognition-challenge**:
   - The prepare.py script incorrectly prepares the test set such that there is a
     much larger range of test labels than there should be.

--- a/mlebench/grade.py
+++ b/mlebench/grade.py
@@ -114,7 +114,7 @@ def validate_submission(submission: Path, competition: Competition) -> tuple[boo
         )
 
     try:
-        competition.grader.grade_fn(read_csv(submission), load_answers(competition.answers))
+        competition.grader.grade_fn(read_csv(submission), read_csv(competition.answers))
     except Exception as e:
         return (
             False,


### PR DESCRIPTION

Raise an issue for a bug in the `validate_submission` function: this bug causes the validation function fails on this competition `tensorflow2-question-answering` because the answer file is `test.jsonl` instead of `test.csv`. 