### PR TITLE
Load JSONL answer files correctly in validate_submission

### DIFF
--- a/mlebench/grade.py
+++ b/mlebench/grade.py
@@ -114,7 +114,7 @@ def validate_submission(submission: Path, competition: Competition) -> tuple[boo
         )
 
     try:
-        competition.grader.grade_fn(read_csv(submission), read_csv(competition.answers))
+        competition.grader.grade_fn(read_csv(submission), load_answers(competition.answers))
     except Exception as e:
         return (
             False,

--- a/tests/unit/test_grade.py
+++ b/tests/unit/test_grade.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pandas as pd
+
+import mlebench.grade as grade_module
+from mlebench.grade import validate_submission
+from mlebench.grade_helpers import Grader
+from mlebench.registry import Competition
+
+
+def _grade_expecting_jsonl_answers(submission: pd.DataFrame, answers: list) -> float:
+    """Grader that expects `answers` to be a list of dicts, as loaded from a JSONL file.
+
+    Mirrors how graders for competitions with `.jsonl` answer files (e.g.
+    tensorflow2-question-answering) consume their answers.
+    """
+    return float(len([row["example_id"] for row in answers]))
+
+
+def _make_competition(answers_path: Path, submission_path: Path, tmp: Path) -> Competition:
+    grader = Grader(
+        name="jsonl-answers-grader",
+        grade_fn=f"{__name__}:_grade_expecting_jsonl_answers",
+    )
+    return Competition(
+        id="jsonl-answers-comp",
+        name="JSONL answers competition",
+        description="Fixture competition whose answers are stored as JSONL.",
+        grader=grader,
+        answers=answers_path,
+        gold_submission=answers_path,
+        sample_submission=submission_path,
+        competition_type="test",
+        prepare_fn=lambda raw, public, private: raw,
+        raw_dir=tmp,
+        private_dir=tmp,
+        public_dir=tmp,
+        checksums=tmp / "checksums.yaml",
+        leaderboard=tmp / "leaderboard.csv",
+    )
+
+
+def test_validate_submission_handles_jsonl_answers(monkeypatch):
+    """validate_submission must load answers via load_answers so JSONL answer
+    files are parsed correctly, matching grade_csv. Regression test for the bug
+    where read_csv was used on `.jsonl` answers, failing every valid submission."""
+    monkeypatch.setattr(
+        grade_module, "is_dataset_prepared", lambda competition, grading_only=False: True
+    )
+
+    with TemporaryDirectory() as d:
+        tmp = Path(d)
+        answers_path = tmp / "test.jsonl"
+        with answers_path.open("w") as f:
+            f.write(json.dumps({"example_id": "a"}) + "\n")
+            f.write(json.dumps({"example_id": "b"}) + "\n")
+
+        submission_path = tmp / "submission.csv"
+        submission_path.write_text("example_id,PredictionString\na,\nb,\n")
+
+        competition = _make_competition(answers_path, submission_path, tmp)
+
+        is_valid, message = validate_submission(submission_path, competition)
+
+    assert is_valid, message
+    assert message == "Submission is valid."


### PR DESCRIPTION
Fixes #134.

`validate_submission` in `mlebench/grade.py` reads the answers file with `read_csv`, but `grade_csv` reads the same file with `load_answers`, which dispatches on the file extension (`.csv` -> `read_csv`, `.jsonl` -> `read_jsonl`).

For competitions whose answers are stored as JSONL, currently `tensorflow2-question-answering` (`answers: .../test.jsonl`), `read_csv` mis-parses the file. The grader then iterates the answers expecting a `list[dict]` and raises, so `validate_submission` reports a perfectly valid submission as invalid. This is already catalogued as a known issue in the README and tracked in #134.

Repro on `main` with a JSONL-answers competition and a valid submission:

```
is_valid: False
message: Submission invalid! The attempt to grade the submission has resulted in the following error message:
string indices must be integers, not 'str'
```

Fix: use `load_answers(competition.answers)` in `validate_submission`, matching `grade_csv`. After the change the same submission validates:

```
is_valid: True
message: Submission is valid.
```

Added `tests/unit/test_grade.py` with a self-contained regression test that builds a fixture competition with a `.jsonl` answers file and asserts `validate_submission` accepts a valid submission. The test fails on the old code (`read_csv`) and passes with the fix.