### PR TITLE
Add ScienceFlow MLE-Bench Results: 70.22% Overall Medal Rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Code for the paper ["MLE-Bench: Evaluating Machine Learning Agents on Machine Le
 
 | Agent | LLM(s) used | Low == Lite (%) | Medium (%) | High (%) | All (%) | Running Time (hours) | Date | Source Code Available | Grading Reports Available |
 |-------|-------------|-----------------|------------|----------|---------|----------------------|------|----------------------|---------------------------|
+| [ScienceFlow](https://huawei-noah.github.io/noah-research/ScienceFlow/website/) | deepseek-v4-flash | 80.30 ± 1.52 | 74.56 ± 0.88 | 44.44 ± 2.22 | 70.22 ± 1.18 | 24 | 2026-07-25 | ✓ | ✓ |
 | [Famou-Agent 2.0](https://github.com/baidubce/FM-Agent) | Gemini-3-Pro-Preview | 80.3 ± 1.52 | 64.04 ± 2.32 | 42.22 ± 2.22 | 64.44 ± 1.18 | 24 | 2026-02-23 | X | ✓ |
 | [AIBuildAI](https://github.com/aibuildai/AI-Build-AI) | Claude-Opus-4.6 |  77.27 ± 0.00 |  61.40 ± 0.88 |  46.67 ± 0.00 | 63.11 ± 0.44 | 24 | 2026-03-06 | X | ✓ |
 | [CAIR](https://research.google/teams/cloud-ai-research/) [MARS+](https://arxiv.org/pdf/2602.02660) | Gemini-3-Pro-Preview | 78.79 ± 1.52 | 60.53 ± 1.52 | 44.44 ± 2.22 | 62.67 ± 0.77 | 24 | 2026-02-17 | X | ✓ |

--- a/runs/README.md
+++ b/runs/README.md
@@ -61,3 +61,4 @@ table below.
 | MARS                    | CAIR MARS, 24 hours, 12 vCPUs, 220GB of RAM, and 1 A100-40GB GPU          |
 | MARS+                    | CAIR MARS+, 24 hours, 48 vCPUs, 220GB of RAM, and 2 × H100 GPUs       |
 | AIBuildAI                            | Claude-Opus-4.6, 24 hours, 24 vCPUs, 256GB of RAM, and 1 A100 GPU |
+| ScienceFlow                          | ScienceFlow, 24 hours, 16-32 logical CPU cores, 256GB of RAM, and compute equivalent to approximately 2-4 Ascend 910C NPUs |

--- a/runs/ScienceFlow_group1/grading_report.json
+++ b/runs/ScienceFlow_group1/grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df7b210774de9e8bb3d08f514c5b3f18024336383e3c04caaab417772b55ea51
+size 32763

--- a/runs/ScienceFlow_group2/grading_report.json
+++ b/runs/ScienceFlow_group2/grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42c59bcc4cdeb3c945f544c4d4acd91c6ba451de5e6a6aa9f7a7b1af5d48f3d
+size 32767

--- a/runs/ScienceFlow_group3/grading_report.json
+++ b/runs/ScienceFlow_group3/grading_report.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dc24b38edac416f63e5709ac12c467721ca36029b14ad24b77558675ef816fd
+size 32771

--- a/runs/run_group_experiments.csv
+++ b/runs/run_group_experiments.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d57c2d6e5794220a80c7e3d91c08764a3d96b60f3cd8e0046d6e45d8362f719
-size 300
+oid sha256:a5fb768fac9519b41dfe6a7babb5836fe100a65ccd2c0ecc4930fb3f47c0f992
+size 5897


### PR DESCRIPTION
Hi MLE-Bench maintainers,

Thank you for developing and maintaining MLE-Bench.

We would like to share the results of [**ScienceFlow**](https://huawei-noah.github.io/noah-research/ScienceFlow/website/), our autonomous long-horizon optimization agent, evaluated on the full benchmark across three independent runs.

**The ScienceFlow source code and technical report will be publicly released in early August 2026.**

For transparency, `tensorflow-speech-recognition-challenge` used the corrected setup described in [#63](https://github.com/openai/mle-bench/issues/63). We report results both with and without its medal; in the latter case, the task remains in the benchmark denominator and is counted as a non-medal.

## Results

| Split | With Corrected-Task Medal | Without Corrected-Task Medal |
|---|---:|---:|
| Low / Lite | 80.30 ± 1.52% | 80.30 ± 1.52% |
| Medium | 74.56 ± 0.88% | 71.93 ± 0.88% |
| High | 44.44 ± 2.22% | 44.44 ± 2.22% |
| Overall | **70.22 ± 1.18%** | **68.89 ± 1.18%** |

## Evaluation Setup

- **Model:** `deepseek-v4-flash`
- **Runs:** Three independent runs
- **Runtime:** 24 hours per competition
- **Hardware:** 16–32 logical CPU cores, 256 GB of RAM, and compute equivalent to approximately 2–4 Ascend 910C NPUs per task

The agent was not exposed to held-out test labels or test-derived signals during search or final submission selection.

We understand that new leaderboard submissions are currently paused. This PR documents our results and accompany with grading reports for future review.

Best regards,  
The ScienceFlow Team